### PR TITLE
A few tweaks to fix the link to the github repo and match the package.json up with the LICENSE file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ node_modules
 .zedstate
 typings
 .vscode
+*.log
+yarn.lock

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bkgdr",
-  "version": "1.1.3",
+  "version": "1.1.4",
   "description": "Bkgdr (backgrounder) -- promise wapper around webworkers.",
   "main": "bkgdr.js",
   "keywords": [
@@ -9,12 +9,26 @@
     "promise"
   ],
   "author": "alan@theprices.us",
-  "license": "ISC",
+  "licenses": [
+    {
+      "type": "Apache-2.0",
+      "url": "http://www.apache.org/licenses/LICENSE-2.0"
+    }
+  ],
   "devDependencies": {
-    "grunt-ts": "5.4.0"
+    "grunt": "^1.0.1",
+    "grunt-ts": "5.4.0",
+    "typescript": "1.7.5"
   },
   "files": [
-      "dist"
-  ]
+    "dist"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/alantheprice/backgrounder.git"
+  },
+  "bugs": {
+    "url": "https://github.com/alantheprice/backgrounder/issues"
+  },
+  "homepage": "https://github.com/alantheprice/backgrounder/"
 }
- 


### PR DESCRIPTION
https://www.npmjs.com/package/bkgdr doesn't currently show a link to the GitHub repository anywhere. This should fix that.